### PR TITLE
Meta migration updates

### DIFF
--- a/commands/class-meta-migrate.php
+++ b/commands/class-meta-migrate.php
@@ -7,15 +7,15 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 	class Today_Migration_Meta {
 		private
 			$key_mapping = array(
-				'updated_date'  => 'post_header_updated_date',
-				'subtitle'      => 'post_header_subtitle',
-				'deck'          => 'post_header_deck',
-				'author_title'  => 'post_author_title',
-				'author_byline' => 'post_author_byline',
-				'author_bio'    => 'post_author_bio',
-				'source'        => 'post_source',
-				'primary_tag'   => 'post_primary_tag',
-				'video_url'     => 'post_header_video_url'
+				'updated_date'  => 'field_5c813a34c81af', // 'post_header_updated_date',
+				'subtitle'      => 'field_5c813b75c81b0', // 'post_header_subtitle',
+				'deck'          => 'field_5c813eaac81b1', // 'post_header_deck',
+				'author_title'  => 'field_5c813ebec81b2', // 'post_author_title',
+				'author_byline' => 'field_5c813f0fc81b4', // 'post_author_byline',
+				'author_bio'    => 'field_5c813f22c81b5', // 'post_author_bio',
+				'source'        => 'field_5c8140e7c81bf', // 'post_source',
+				'primary_tag'   => 'field_5c8140a1c81bd', // 'post_primary_tag',
+				'video_url'     => 'field_5c814048c81bb', // 'post_header_video_url'
 			),
 			$progress;
 
@@ -53,7 +53,7 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 		}
 
 		/**
-		 * Helper function to convert meta fields
+		 * Helper function to convert meta fields to new ACF fields
 		 * @author Jim Barnes
 		 * @since 1.0.0
 		 * @param WP_Post $post The post object
@@ -63,7 +63,7 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 
 			foreach ( $this->key_mapping as $old_key => $new_key ) {
 				$value = get_post_meta( $post_id, $old_key, true );
-				update_post_meta( $post_id, $new_key, $value );
+				update_field( $new_key, $value, $post_id );
 			}
 		}
 

--- a/commands/class-meta-migrate.php
+++ b/commands/class-meta-migrate.php
@@ -6,7 +6,7 @@
 if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 	class Today_Migration_Meta {
 		private
-			$mapping = array(
+			$key_mapping = array(
 				'updated_date'  => 'post_header_updated_date',
 				'subtitle'      => 'post_header_subtitle',
 				'deck'          => 'post_header_deck',
@@ -42,7 +42,8 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 			);
 
 			foreach ( $posts as $post ) {
-				$this->convert_meta( $post );
+				$this->convert_meta_keys( $post );
+				$this->convert_meta_values( $post );
 				$this->progress->tick();
 			}
 
@@ -57,17 +58,36 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 		 * @since 1.0.0
 		 * @param WP_Post $post The post object
 		 */
-		private function convert_meta( $post ) {
+		private function convert_meta_keys( $post ) {
 			$post_id = $post->ID;
 
-			foreach( $this->mapping as $old_key => $new_key ) {
-				$value = get_post_meta( $post_id, $old_key );
-
-				if ( count( $value ) === 1 ) {
-					$value = $value[0];
-				}
-
+			foreach ( $this->key_mapping as $old_key => $new_key ) {
+				$value = get_post_meta( $post_id, $old_key, true );
 				update_post_meta( $post_id, $new_key, $value );
+			}
+		}
+
+		/**
+		 * Helper function to convert specific meta values
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param WP_Post $post The post object
+		 */
+		private function convert_meta_values( $post ) {
+			// Update templates for single posts. The old 'featured'
+			// template is the new default in the Today Child Theme,
+			// and the old default is now `template-twocol.php`.
+			$page_template = get_post_meta( $post->ID, '_wp_page_template', true );
+			switch ( $page_template ) {
+				case 'default':
+				case '':
+					update_post_meta( $post->ID, '_wp_page_template', 'template-twocol.php' );
+					break;
+				case 'featured-single-post.php':
+					update_post_meta( $post->ID, '_wp_page_template', 'default' );
+					break;
+				default:
+					break;
 			}
 		}
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated meta key updates to save using ACF's `update_field()` function.  Using this function, along with ACF field keys instead of standard meta keys, ensures these field values save properly and with formatting expected according to each ACF field's configuration.
- Removed multi-value handling when fetching old meta field data--I was running into issues with saving multiple returned values and getting arrays back where `get_field()` is called in the theme.  Not sure if there was a specific reason for including this, but as far as I'm aware, we shouldn't need to store multiple values for any of the meta data we're migrating here anyway.
- Added `convert_meta_values()` method, which updates assigned post templates for stories to match new template names.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes issues with saving and retrieving updated meta data through ACF
- Adds conversion of story templates necessary for the new theme

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Only tested locally so far.  We can give this a go in Dev once it's installed there.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
