### PR TITLE
Featured image migration - alternative first attachments

### DIFF
--- a/commands/class-featured-image-migrate.php
+++ b/commands/class-featured-image-migrate.php
@@ -5,8 +5,7 @@
 if ( ! class_exists( 'Today_Migration_Featured_Image' ) ) {
 	class Today_Migration_Featured_Image {
 		private
-			$custom_meta_field = 'post_header_image',
-			$acf_field_id      = 'field_5c813f8ac81b8',
+			$acf_field_id = 'field_5c813f8ac81b8', // post_header_image
 			$progress,
 			$converted = 0;
 

--- a/commands/class-featured-image-migrate.php
+++ b/commands/class-featured-image-migrate.php
@@ -6,8 +6,9 @@ if ( ! class_exists( 'Today_Migration_Featured_Image' ) ) {
 	class Today_Migration_Featured_Image {
 		private
 			$custom_meta_field = 'post_header_image',
+			$acf_field_id      = 'field_5c813f8ac81b8',
 			$progress,
-			$converted;
+			$converted = 0;
 
 		/**
 		 * Converts featured images to a custom meta field.
@@ -46,12 +47,36 @@ if ( ! class_exists( 'Today_Migration_Featured_Image' ) ) {
 		 */
 		private function convert_featured_image( $post ) {
 			$post_id  = $post->ID;
-			$image_id = get_post_thumbnail_id( $post_id );
+			$image_id = $this->get_post_primary_image_id( $post_id );
 
 			if ( $image_id ) {
-				update_post_meta( $post_id, $this->custom_meta_field, $image_id );
+				update_field( $this->acf_field_id, $image_id, $post_id );
 				$this->converted++;
 			}
+		}
+
+		/**
+		 * Returns the ID of the featured image, if set, or the
+		 * ID of the first available attachment for the post.
+		 */
+		private function get_post_primary_image_id( $post_id ) {
+			$image_id = null;
+
+			$thumbnail_id = get_post_thumbnail_id( $post_id );
+
+			if ( $thumbnail_id ) {
+				$image_id = $thumbnail_id;
+			}
+			else {
+				$attachments = get_attached_media( 'image', $post_id );
+				if ( is_array( $attachments ) && ! empty( $attachments ) ) {
+					// Get the first attachment ID returned
+					reset( $attachments );
+					$image_id = key( $attachments );
+				}
+			}
+
+			return $image_id;
 		}
 	}
 


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added logic to fetch the first available attachment if a featured image isn't available
- Updated meta value save to use `update_field()` to handle field key references appropriately for ACF

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps ensure a post header image is assigned similarly to how Today-Bootstrap's default story template behaves.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally; can review in Dev once plugin is installed.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
