### PR TITLE
Added tag removal command

### DIFF
--- a/commands/class-run-all.php
+++ b/commands/class-run-all.php
@@ -29,6 +29,9 @@ if ( ! class_exists( 'Today_Migration_All' ) ) {
 			$css = new Today_Migration_CSS_Classes();
 			$css->__invoke( $args );
 
+			$tags = new Today_Migration_Tag_Removal();
+			$tags->__invoke( $args );
+
 			WP_CLI::success( "Finished running all tasks." );
 		}
 	}

--- a/commands/class-tag-removal.php
+++ b/commands/class-tag-removal.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Removes tags that only have one post assigned to them
+ */
+if ( ! class_exists( 'Today_Migration_Tag_Removal' ) ) {
+	class Today_Migration_Tag_Removal {
+		private
+			$progress,
+			$total_tags = 0,
+			$removed = 0;
+
+		/**
+		 * Removes tags that only have one or less posts assigned to them
+		 *
+		 * ## EXAMPLES
+		 *
+		 * 		wp today migrate tags
+		 *
+		 * @when after_wp_load
+		 */
+		public function __invoke( $args ) {
+			// Get all tags
+			$terms = get_terms( array(
+				'taxonomy'   => 'post_tag',
+				'hide_empty' => false
+			) );
+
+			$this->total_tags = count( $terms );
+
+			$this->progress = WP_CLI\Utils\make_progress_bar(
+				'Removing tags with 1 or less posts assigned...',
+				$this->total_tags
+			);
+
+			foreach ( $terms as $term ) {
+				$this->maybe_remove_tag( $term );
+				$this->progress->tick();
+			}
+
+			$this->progress->finish();
+			WP_CLI::success( "Removed $this->removed out of $this->total_tags tags." );
+		}
+
+		/**
+		 * Removes a tag from WordPress if it's count is less than 2
+		 * @author Jim Barnes
+		 * @since 1.0.2
+		 * @
+		 */
+		private function maybe_remove_tag( $term ) {
+			if ( $term->count < 2 ) {
+				wp_delete_term( $term->term_id, 'post_tag' );
+				$this->removed++;
+			}
+		}
+	}
+
+	WP_CLI::add_command( 'today migrate tags', 'Today_Migration_Tag_Removal' );
+}

--- a/today-migration-plugin.php
+++ b/today-migration-plugin.php
@@ -14,5 +14,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once dirname( __FILE__ ) . '/commands/class-featured-image-migrate.php';
 	require_once dirname( __FILE__ ) . '/commands/class-css-class-migrate.php';
 	require_once dirname( __FILE__ ) . '/commands/class-post-content-migrate.php';
+	require_once dirname( __FILE__ ) . '/commands/class-tag-removal.php';
 	require_once dirname( __FILE__ ) . '/commands/class-run-all.php';
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a command that removes all post_tags with less than 2 posts assigned to them.

**Motivation and Context**
This is the first step in cleaning up the tags in Today.

**How Has This Been Tested?**
The migration task has been run in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
