### PR TITLE
Added additional preg_replace to get rid of u tags

### DIFF
--- a/commands/class-post-content-migrate.php
+++ b/commands/class-post-content-migrate.php
@@ -49,6 +49,13 @@ if ( ! class_exists( 'Today_Migration_Post_Content' ) ) {
 			global $wpdb;
 			$post_content = $post->post_content;
 
+			// Super special <u> tag removal on everything
+			$post_content = preg_replace(
+				'/\<\/?u(.|\s)*?\>/i',
+				'',
+				$post_content
+			);
+
 			if ( get_page_template_slug( $post->ID ) === '' ) {
 				$post_content = strip_tags( $post_content, $this->allowed_tags );
 			}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Removes all `<u>` tags from content during the post content migration.

**Motivation and Context**
The `<u>` tag doesn't seemed to be used in a semantically correct way anywhere in the site currently, so we're just removing it.

**How Has This Been Tested?**
Hasn't been tested yet as we need test data to test again.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
