### PR TITLE
Post date update

### DIFF
--- a/commands/class-meta-migrate.php
+++ b/commands/class-meta-migrate.php
@@ -7,7 +7,6 @@ if ( ! class_exists( 'Today_Migration_Meta' ) ) {
 	class Today_Migration_Meta {
 		private
 			$key_mapping = array(
-				'updated_date'  => 'field_5c813a34c81af', // 'post_header_updated_date',
 				'author_title'  => 'field_5c813ebec81b2', // 'post_author_title',
 				'author_byline' => 'field_5c813f0fc81b4', // 'post_author_byline',
 				'author_bio'    => 'field_5c813f22c81b5', // 'post_author_bio',

--- a/commands/class-post-content-migrate.php
+++ b/commands/class-post-content-migrate.php
@@ -61,15 +61,16 @@ if ( ! class_exists( 'Today_Migration_Post_Content' ) ) {
 			}
 
 			// Convert post_date and add post_header_publish_date if needed.
-			$updated_date  = $post->post_date;
-			$publish_date  = get_post_meta( $post->ID, 'updated_date', true );
+			$updated_date  = get_post_meta( $post->ID, 'updated_date', true );
+			$publish_date  = $post->post_date;
 
-			$orig_pub_date = isset( $publish_date ) ? date( 'Y-m-d', strtotime( $publish_date ) ) : $updated_date;
+			$updated_date_formatted = isset( $updated_date ) ? date( 'Y-m-d H:i:s', strtotime( $updated_date ) ) : $publish_date;
+			$publish_date_formatted = date( 'Y-m-d', strtotime( $publish_date ) );
 
 			if ( $post->post_content !== $post_content ) {
-				$update_status = $wpdb->update( $wpdb->posts, array( 'post_content' => $post_content ), array( 'ID' => $post->ID ), array( 'post_date' => $updated_date ) );
+				$update_status = $wpdb->update( $wpdb->posts, array( 'post_content' => $post_content ), array( 'ID' => $post->ID ), array( 'post_date' => $updated_date_formatted ) );
 
-				update_post_meta( $post->ID, 'post_header_publish_date', $orig_pub_date );
+				update_post_meta( $post->ID, 'post_header_publish_date', $publish_date_formatted );
 
 				if ( $update_status !== false ) {
 					$this->converted++;

--- a/commands/class-post-content-migrate.php
+++ b/commands/class-post-content-migrate.php
@@ -60,8 +60,17 @@ if ( ! class_exists( 'Today_Migration_Post_Content' ) ) {
 				$post_content = strip_tags( $post_content, $this->allowed_tags );
 			}
 
+			// Convert post_date and add post_header_publish_date if needed.
+			$updated_date  = $post->post_date;
+			$publish_date  = get_post_meta( $post->ID, 'updated_date', true );
+
+			$orig_pub_date = isset( $publish_date ) ? date( 'Y-m-d', strtotime( $publish_date ) ) : $updated_date;
+
 			if ( $post->post_content !== $post_content ) {
-				$update_status = $wpdb->update( $wpdb->posts, array( 'post_content' => $post_content ), array( 'ID' => $post->ID ) );
+				$update_status = $wpdb->update( $wpdb->posts, array( 'post_content' => $post_content ), array( 'ID' => $post->ID ), array( 'post_date' => $updated_date ) );
+
+				update_post_meta( $post->ID, 'post_header_publish_date', $orig_pub_date );
+
 				if ( $update_status !== false ) {
 					$this->converted++;
 					clean_post_cache( $post->ID );


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a step that makes sure both `post_date` field and the `post_header_publish_date` meta field are set. If the post has the deprecated `updated_date` meta field, it will be set as the `post_date`. The `post_date` is always set as the `post_header_publish_date`.

**Motivation and Context**
Converts the old meta values to work with the new schema being used in the new theme/plugins.

**How Has This Been Tested?**
Conversion has been tested locally. Setting up a test in develop requires wiping out everything that's there now, so it needs to be coordinated.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
