### PR TITLE
Updated isset to not empty

### DIFF
--- a/commands/class-post-content-migrate.php
+++ b/commands/class-post-content-migrate.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'Today_Migration_Post_Content' ) ) {
 			$updated_date  = get_post_meta( $post->ID, 'updated_date', true );
 			$publish_date  = $post->post_date;
 
-			$updated_date_formatted = isset( $updated_date ) ? date( 'Y-m-d H:i:s', strtotime( $updated_date ) ) : $publish_date;
+			$updated_date_formatted = ( ! empty( $updated_date ) ) ? date( 'Y-m-d H:i:s', strtotime( $updated_date ) ) : $publish_date;
 			$publish_date_formatted = date( 'Y-m-d', strtotime( $publish_date ) );
 
 			if ( $post->post_content !== $post_content || $updated_date_formatted !== $post->post_date ) {


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Quick bug fix for the post content importer. Makes sure that the `updated_date` is set, not null and not an empty string.

**Motivation and Context**
When running the migration in develop, it seems like the `updated_date` meta_value was coming back as an empty string, which `isset` does not test. This was causing publish dates to be set to 1-1-70.

**How Has This Been Tested?**
It will have to be tested in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
