### PR TITLE
Duplicate images script - undefined index 'sizes' fix

### DIFF
--- a/commands/class-duplicate-images.php
+++ b/commands/class-duplicate-images.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'Today_Migration_Duplicate_Images' ) ) {
 			// No header image, then return
 			if ( ! $image || ! isset( $image['sizes'] ) ) return;
 
-			$pattern = '/(\[caption.*?\])?<img.*?src="(';
+			$pattern = '/(\[caption.*?\])?(<a.*>)?<img.*?src="(';
 
 			$img_urls = array();
 
@@ -66,7 +66,7 @@ if ( ! class_exists( 'Today_Migration_Duplicate_Images' ) ) {
 				}
 			}
 
-			$pattern .= implode( '|', $img_urls ) . ')"(.*)?\/?>(.*)?(\[\/caption\])?/i';
+			$pattern .= implode( '|', $img_urls ) . ')"(.*)?\/?>(.*)?(<\/a>)?(\[\/caption\])?/i';
 
 			$post_content = $post->post_content;
 

--- a/commands/class-duplicate-images.php
+++ b/commands/class-duplicate-images.php
@@ -54,9 +54,9 @@ if ( ! class_exists( 'Today_Migration_Duplicate_Images' ) ) {
 			$image = get_field( $this->acf_header_image_id, $post->ID );
 
 			// No header image, then return
-			if ( ! $image ) return;
+			if ( ! $image || ! isset( $image['sizes'] ) ) return;
 
-			$pattern = '/(\[caption.*?\])?(<a.*>)?<img.*?src="(';
+			$pattern = '/(\[caption.*?\])?<img.*?src="(';
 
 			$img_urls = array();
 
@@ -66,7 +66,7 @@ if ( ! class_exists( 'Today_Migration_Duplicate_Images' ) ) {
 				}
 			}
 
-			$pattern .= implode( '|', $img_urls ) . ')"(.*)?\/?>(.*)?(<\/a>)?(\[\/caption\])?/i';
+			$pattern .= implode( '|', $img_urls ) . ')"(.*)?\/?>(.*)?(\[\/caption\])?/i';
 
 			$post_content = $post->post_content;
 


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Migration-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Migration-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a check to ensure `$images['sizes']` is set before attempting to loop through it.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Apparently this key can be not set on images returned by `get_field()` somehow.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested locally.  Plan on reviewing completely against QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
